### PR TITLE
Fix Ottomans

### DIFF
--- a/localisation/countries_l_english.yml
+++ b/localisation/countries_l_english.yml
@@ -247,7 +247,7 @@
  TRP:0 "Tripoli"
  TRV:0 "Travanacore"
  TUN:0 "Tunis"
- TUR:0 "Devlet-i Aliye"
+ TUR:0 "Devlet-i Osmaniye"
  TUS:0 "Toscana"
  TVE:0 "Tver"
  TYR:0 "Tír Eoghain"


### PR DESCRIPTION
The official name of the Ottomans was "Devlet-i Aliye-i Osmaniye" which translates to "Sublime Ottoman State". "Devlet-i Aliye" means "Sublime State", "Devlet-i Osmaniye" means "Ottoman State". I think that's more appropriate as a country name.